### PR TITLE
Redesign top navigation to match Stripe's style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -122,6 +122,9 @@
   body {
     @apply bg-background text-foreground;
   }
+  html {
+    scroll-padding-top: 4rem; /* Account for 64px (h-16) sticky header */
+  }
 }
 
 .prose {

--- a/components/docs-layout.tsx
+++ b/components/docs-layout.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import * as React from "react"
-import { Menu, X } from "lucide-react"
-import { Sidebar, type NavItem } from "@/components/ui/sidebar"
-import { Button } from "@/components/ui/button"
+import Link from "next/link"
+import { ChevronLeft } from "lucide-react"
+import { TopNavigation, type NavItem } from "@/components/top-navigation"
 import { cn } from "@/lib/utils"
 
 interface DocsLayoutProps {
@@ -13,53 +13,91 @@ interface DocsLayoutProps {
 }
 
 export function DocsLayout({ navigation, children, title }: DocsLayoutProps) {
-  const [sidebarOpen, setSidebarOpen] = React.useState(false)
+  const [activeSection, setActiveSection] = React.useState<string>("")
+  const [isSidebarOpen, setIsSidebarOpen] = React.useState(true)
+
+  // Get the active navigation item with sub-items
+  const activeSectionData = React.useMemo(() => {
+    return navigation.find(item => item.title === activeSection && item.items)
+  }, [navigation, activeSection])
+
+  // Reset sidebar when activeSection changes
+  React.useEffect(() => {
+    if (activeSectionData) {
+      setIsSidebarOpen(true)
+    }
+  }, [activeSectionData])
 
   return (
-    <div className="flex min-h-screen">
-      {/* Mobile sidebar toggle */}
-      <div className="fixed top-4 left-4 z-50 lg:hidden">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => setSidebarOpen(!sidebarOpen)}
-          aria-label="Toggle sidebar"
-        >
-          {sidebarOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
-        </Button>
-      </div>
+    <div className="min-h-screen bg-slate-50 dark:bg-background">
+      {/* Top Navigation */}
+      <TopNavigation
+        navigation={navigation}
+        title={title}
+        activeSection={activeSection}
+        onSectionChange={setActiveSection}
+      />
 
-      {/* Sidebar for desktop */}
-      <div className="hidden lg:block">
-        <Sidebar navigation={navigation} />
-      </div>
+      <div className="flex">
+        {/* Left Sidebar - Only shown when there's an active section with items */}
+        {activeSectionData && activeSectionData.items && (
+          <>
+            {/* Desktop Sidebar */}
+            <aside
+              className={cn(
+                "hidden lg:block sticky top-16 h-[calc(100vh-4rem)] w-64 border-r bg-white dark:bg-background transition-all",
+                isSidebarOpen ? "translate-x-0" : "-translate-x-full"
+              )}
+            >
+              <div className="p-6">
+                <div className="flex items-center justify-between mb-6">
+                  <h3 className="text-base font-semibold text-[#635bff]">
+                    {activeSectionData.title}
+                  </h3>
+                  <button
+                    onClick={() => setIsSidebarOpen(false)}
+                    className="p-1 hover:bg-slate-100 dark:hover:bg-slate-800 rounded"
+                    aria-label="Close sidebar"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </button>
+                </div>
+                <nav className="space-y-1">
+                  {activeSectionData.items.map((item) => (
+                    <Link
+                      key={item.title}
+                      href={item.href}
+                      className="block px-3 py-2 text-sm text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-md transition-colors"
+                    >
+                      {item.title}
+                    </Link>
+                  ))}
+                </nav>
+              </div>
+            </aside>
 
-      {/* Mobile sidebar overlay */}
-      {sidebarOpen && (
-        <>
-          <div
-            className="fixed inset-0 z-40 bg-background/80 backdrop-blur-sm lg:hidden"
-            onClick={() => setSidebarOpen(false)}
-          />
-          <div className="fixed inset-y-0 left-0 z-50 lg:hidden">
-            <Sidebar navigation={navigation} className="shadow-lg" />
+            {/* Sidebar toggle button when closed */}
+            {!isSidebarOpen && (
+              <button
+                onClick={() => setIsSidebarOpen(true)}
+                className="hidden lg:block fixed left-0 top-20 p-2 bg-white dark:bg-slate-800 border border-l-0 rounded-r-md shadow-md z-40"
+                aria-label="Open sidebar"
+              >
+                <ChevronLeft className="h-4 w-4 rotate-180" />
+              </button>
+            )}
+          </>
+        )}
+
+        {/* Main content area */}
+        <main className="flex-1 overflow-y-auto">
+          <div className="container mx-auto max-w-5xl px-6 py-8 lg:px-8 lg:py-12">
+            <div className="prose prose-slate dark:prose-invert max-w-none">
+              {children}
+            </div>
           </div>
-        </>
-      )}
-
-      {/* Main content area */}
-      <main className="flex-1 overflow-y-auto">
-        <div className="container mx-auto max-w-4xl px-6 py-8 lg:px-8 lg:py-12">
-          {title && (
-            <header className="mb-8 border-b border-border pb-6">
-              <h1 className="text-4xl font-bold tracking-tight">{title}</h1>
-            </header>
-          )}
-          <div className="prose prose-slate dark:prose-invert max-w-none">
-            {children}
-          </div>
-        </div>
-      </main>
+        </main>
+      </div>
     </div>
   )
 }

--- a/components/top-navigation.tsx
+++ b/components/top-navigation.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+
+export interface NavItem {
+  title: string
+  href?: string
+  items?: { title: string; href: string }[]
+}
+
+interface TopNavigationProps {
+  navigation: NavItem[]
+  title?: string
+  activeSection?: string
+  onSectionChange?: (section: string) => void
+}
+
+export function TopNavigation({ navigation, title, activeSection, onSectionChange }: TopNavigationProps) {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = React.useState(false)
+  const [currentHash, setCurrentHash] = React.useState("")
+
+  // Track hash changes
+  React.useEffect(() => {
+    const updateHash = () => {
+      const hash = window.location.hash || "#about" // Default to #about if no hash
+      setCurrentHash(hash)
+    }
+    updateHash()
+    window.addEventListener("hashchange", updateHash)
+    return () => window.removeEventListener("hashchange", updateHash)
+  }, [])
+
+  const handleSectionClick = (item: NavItem) => {
+    if (item.href) {
+      // For items with direct hrefs, clear active section
+      if (onSectionChange) {
+        onSectionChange("")
+      }
+      // Manually update hash for immediate feedback
+      setTimeout(() => setCurrentHash(item.href), 0)
+    } else if (item.items && onSectionChange) {
+      // For items with sub-items (Experience), set as active section and navigate to #experience
+      onSectionChange(item.title)
+      // Clear the hash to remove active indicators from other tabs
+      setCurrentHash("")
+      // Navigate to the experience section
+      const experienceSection = document.getElementById("experience")
+      if (experienceSection) {
+        experienceSection.scrollIntoView({ behavior: "smooth" })
+      }
+    }
+  }
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-[#ffffff] dark:bg-background">
+      <nav className="container mx-auto flex h-16 items-center justify-between px-6">
+        {/* Logo/Title */}
+        <div className="flex items-center mr-8">
+          <Link href="/" className="text-xl font-semibold hover:opacity-80 transition-opacity">
+            {title || "Dave Ishii"}
+          </Link>
+        </div>
+
+        {/* Desktop Navigation - Flat Tabs */}
+        <div className="hidden md:flex items-center flex-1 space-x-6">
+          {navigation.map((item) => {
+            // Determine if this tab is active
+            let isActive = false
+            if (item.items) {
+              // For items with sub-items (Experience), check if it's the active section
+              isActive = activeSection === item.title
+            } else if (item.href) {
+              // For items with direct hrefs, check if hash matches
+              isActive = currentHash === item.href
+            }
+
+            return (
+              <div key={item.title} className="relative">
+                {item.href ? (
+                  <Link
+                    href={item.href}
+                    onClick={(e) => {
+                      handleSectionClick(item)
+                    }}
+                    className={cn(
+                      "text-sm font-medium py-5 block border-b-2 transition-colors",
+                      isActive
+                        ? "text-[#635bff] border-[#635bff]"
+                        : "text-slate-600 dark:text-slate-300 border-transparent hover:text-slate-900 dark:hover:text-slate-100"
+                    )}
+                  >
+                    {item.title}
+                  </Link>
+                ) : (
+                  <button
+                    onClick={() => handleSectionClick(item)}
+                    className={cn(
+                      "text-sm font-medium py-5 block border-b-2 transition-colors",
+                      isActive
+                        ? "text-[#635bff] border-[#635bff]"
+                        : "text-slate-600 dark:text-slate-300 border-transparent hover:text-slate-900 dark:hover:text-slate-100"
+                    )}
+                  >
+                    {item.title}
+                  </button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+
+        {/* Mobile Menu Button */}
+        <button
+          className="md:hidden p-2"
+          onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-label="Toggle menu"
+        >
+          <svg
+            className="h-6 w-6"
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            {isMobileMenuOpen ? (
+              <path d="M6 18L18 6M6 6l12 12" />
+            ) : (
+              <path d="M4 6h16M4 12h16M4 18h16" />
+            )}
+          </svg>
+        </button>
+      </nav>
+
+      {/* Mobile Menu */}
+      {isMobileMenuOpen && (
+        <div className="md:hidden border-t bg-background">
+          <div className="container mx-auto px-6 py-4 space-y-2">
+            {navigation.map((item) => (
+              <Link
+                key={item.title}
+                href={item.href || "#"}
+                onClick={() => {
+                  setIsMobileMenuOpen(false)
+                  handleSectionClick(item)
+                }}
+                className="block px-4 py-2 text-sm font-medium rounded-md hover:bg-accent transition-colors"
+              >
+                {item.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </header>
+  )
+}


### PR DESCRIPTION
Redesigns the top menu navigation to match Stripe's documentation style as requested in #2.

  Changes

  - Horizontal tab navigation with flat design instead of dropdown menus
  - Blue active indicator (#635bff) with underline for active tabs
  - Context-aware sidebar that appears only for sections with sub-items (Experience)
  - Removed search bar for cleaner interface
  - Fixed scroll offset to account for sticky header (4rem padding)
  - Default active state set to "About" on page load
  - Smart active state tracking via hash navigation for About, Publications, and Contact

  Features

  - Active indicator properly moves between all tabs
  - Clicking "Experience" shows sidebar with sub-navigation and auto-scrolls to section
  - Clicking other tabs hides sidebar and updates active state
  - Responsive mobile menu maintained
  - Smooth scroll behavior with proper offset for sticky header

  Visual Design

  Matches Stripe docs.stripe.com with:
  - Clean white background
  - Stripe purple accent color (#635bff)
  - Professional typography and spacing
  - Three-column layout (logo | navigation | content)
<img width="1904" height="768" alt="Screenshot 2026-01-02 at 12 23 59 PM" src="https://github.com/user-attachments/assets/70e9f6d5-4234-40f1-90d0-8bf922dee7ab" />
<img width="1897" height="882" alt="Screenshot 2026-01-02 at 12 24 13 PM" src="https://github.com/user-attachments/assets/00a096c9-f2bd-48f2-9218-145dd41cdb0e" />
